### PR TITLE
Make use of the argparse libary

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,16 @@
+#!/usr/bin/env python
 # -*- coding: UTF-8 -*-
+"""
+    openings-helper
+    ~~~~~~~~~~~~~~~
 
+    A small script for downloading videos from http://openings.moe
+"""
 import os
 import urllib.request
 import json
 import sys
+from argparse import ArgumentParser
 
 # Set colors
 class bcolors:
@@ -16,55 +23,66 @@ class bcolors:
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'
 
-def usage(): # Sorry in advance for this one
-    print('\nUsage: ' + sys.argv[0]  + ' [option] [query]\n\n' + bcolors.YELLOW + 'Sample usage:\n' + sys.argv[0] + ' --search geass\n' + sys.argv[0] + ' --download geass' + bcolors.ENDC + '\n\n--search | -s\n    Searches for all videos matching the query provided.\n\n--download | -d\n    Downloads all videos matching the query provided into the current working folder.\n\nTo use multiple words in a search, surround them in quotes. eg:\n' + sys.argv[0] + ' -d "Code Geass"\n')
+
+def controller():
+    """Command line parser"""
+    parser = ArgumentParser(description="Openings.moe batch downloader")
+    parser.add_argument("--search", "-s", metavar="PATTERN",
+            help="Search videos matching the query provided.")
+    parser.add_argument("--download", "-d", metavar="PATTERN",
+            help="Download all videos matching the query provided into the current working folder.")
+    args = parser.parse_args()
+
+    if args.search:
+        search(args.search)
+    elif args.download:
+        download(args.download)
+    else:
+        parser.print_help()
     sys.exit()
 
-# Obtain all videos from the json API
+
 def getvideolist():
+    """Obtain all videos from the json API."""
     url = 'http://openings.moe/api/list.php'
     response = urllib.request.urlopen(url)
     lstjson = response.read().decode('utf-8', 'ignore')
     videolist = json.loads(lstjson)
     return videolist
 
-def checkquery():
-    if len(sys.argv) <= 2:
-        print('Missing query. Use ' + sys.argv[0] + ' --help for information')
-        sys.exit()
 
 def downloadvideo(filename):
+    """Download a video with given filename."""
     url = "http://openings.moe/video/" + filename
     f = urllib.request.urlopen(url)
-    print(bcolors.PURPLE + url + bcolors.ENDC + ":\nSaving to --> " + bcolors.YELLOW + filename + bcolors.ENDC)
+    print(bcolors.PURPLE + url + bcolors.ENDC + ":\nSaving to --> "
+            + bcolors.YELLOW + filename + bcolors.ENDC)
     with open(os.path.basename(url), "wb") as local_file:
         local_file.write(f.read())
 
-if len(sys.argv) <= 1:
-    usage()
-    sys.exit()
 
-option = sys.argv[1].lower()
-
-# Download feature
-if option == "--download" or  option == "-d":
-    checkquery()
-    print('\nDownloading all files matching ' + bcolors.YELLOW + sys.argv[2] + bcolors.ENDC + "\n")
-    query = sys.argv[2].lower()
+def download(pattern):
+    """Download all videos matching the given pattern."""
+    query = pattern.lower()
     videolist = getvideolist()
     for video in videolist:
-        if query in video['source'].lower() or query in video['file'].lower() or query in video['title'].lower():
+        if (query in video['source'].lower()
+                or query in video['file'].lower()
+                or query in video['title'].lower()):
             downloadvideo(video['file'])
-# Search feature
-elif option == "--search" or option == "-s":
-    checkquery()
-    print ('Searching for files matching "' + sys.argv[2] + '" from openings.moe')
-    query = sys.argv[2].lower()
+
+
+def search(pattern):
+    """Search and return all videos matching the given pattern."""
+    query = pattern.lower()
     videolist = getvideolist()
     for video in videolist:
-        if query in video['source'].lower() or query in video['file'].lower() or query in video['title'].lower():
-            print(bcolors.YELLOW + video['file'] + bcolors.ENDC + " - " + video['source'] + " - " + video['title'])
-elif option == "--help" or option == "-h":
-    usage()
-else:
-    usage()
+        if (query in video['source'].lower()
+                or query in video['file'].lower()
+                or query in video['title'].lower()):
+            print(bcolors.YELLOW + video['file'] + bcolors.ENDC + " - "
+                    + video['source'] + " - " + video['title'])
+
+
+if __name__ == '__main__':
+    controller()


### PR DESCRIPTION
Python has a great [libary](https://docs.python.org/3.4/library/argparse.html#module-argparse) for parsing command line arguments.
The [print_help()](https://docs.python.org/3.4/library/argparse.html#argparse.ArgumentParser.print_help) function is pretty handy for generating a help message.

Furthermore:
- Remove unused `usage()` function
- Remove unused `checkquery()` function
- Code cleanup
